### PR TITLE
readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ layers](docs/terraform_layers.md):
 
 ### For the `k8s` provider
 
-- `k8s/heater` (simple web-app cluster used to generate load)
-- `k8s/siege-engine` (simple web-client cluster used to generate load)
-- `k8s/prometheus` (uses the helm provider to install prometheus-operator)
+- `k8s/heater` (simple web-app cluster used to simulate a web service)
+- `k8s/siege-engine` (simple web-client cluster used to generate load on heater app)
+- `k8s/prometheus` (used to collect data on performance of heater)
 - `k8s/postgresql` (uses the helm provider)
 - `k8s/core` (namespaces, helm/tiller, etc)
 


### PR DESCRIPTION
"heater" is the app we want to optimize/provide/keep working, right? In our previous conversations, I'd thought that the "heater" was the thing that was **stressing** the web app (but that's the siege engine) that we want to optimize/keep working.

I don't know if "This project stores terraform state separately for each layer. " is necessary. I wonder if it is either self-evident for some people and beyond the necessary scope for others. Just knowing that it saves state in S3/Spaces might be enough.

Is the seige app smart enough that I could point it at a Discourse instance and it'd load multiple pages? It might help to explain more about whether it's just loading the root page over and over as fast as possible or if it's doing something more sophisticated.